### PR TITLE
repair dht.py wrong readings

### DIFF
--- a/client/ipa/dht.py
+++ b/client/ipa/dht.py
@@ -15,7 +15,9 @@ class Dht:
     self._log.info('sensor=%d pin=%d retries=%d' % (Dht._SENSOR, Dht._PIN, Dht._RETRIES))
 
   def get_sample(self):
-    humidity, temperature = Adafruit_DHT.read_retry(Dht._SENSOR, Dht._PIN, retries=Dht._RETRIES)
-    if humidity == None or temperature == None:
-      self._log.warning('failed to read temperature/humidity')
+    humidity = 3300
+    while humidity > 100:
+       humidity, temperature = Adafruit_DHT.read_retry(Dht._SENSOR, Dht._PIN, retries=Dht._RETRIES)
+       if humidity == None or temperature == None:
+         self._log.warning('failed to read temperature/humidity')
     return 'temp_hum', (common.timestamp(), temperature, humidity)


### PR DESCRIPTION
Repairing dht.py to prevent wrong readings when long cables are placed in the DHT sensor. Sometimes I get humidity = 3300. This change prevents values higher than 100 in humidity.